### PR TITLE
feat: compatible with table styles

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 shamefully-hoist=true
+use-node-version=14.21.3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 You can visit <https://ceynri.cn/> to experience.
 
-> [Gridsome](https://github.com/Gridsome/Gridsome) looks like out of maintenance, so I am looking for a substitute for Gridsome later on. If you have a good recommendation, welcome to communicate with me! 😉
+> [Gridsome](https://github.com/Gridsome/Gridsome) looks like out of maintenance, so I will rewrite this project with [astro](https://github.com/withastro/astro) in the future! 🚀
 
 ## Introduction
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "dev": "gridsome develop",
     "explore": "gridsome explore"
   },
+  "engines": {
+    "node": "= 14",
+    "pnpm": ">= 9"
+  },
   "dependencies": {
     "giscus": "~1.3.0",
     "gsap": "^3.6.1"

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -105,10 +105,12 @@
       }
     }
 
-    blockquote img {
-      margin-left: auto;
-      margin-right: auto;
-      width: 100%;
+    blockquote, table {
+      img {
+        margin-left: auto;
+        margin-right: auto;
+        width: 100%;
+      }
     }
 
     br:last-child {

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -105,3 +105,36 @@ ol {
     margin-bottom: 0.6em;
   }
 }
+
+/* Tables */
+table { 
+  border-collapse: collapse; 
+  border-spacing: 0; 
+  width: 100%;
+}
+
+td { 
+  vertical-align: top; 
+}
+
+table {
+  margin-bottom: 1em;
+  font-size: 0.889em;
+}
+
+table th {
+  font-weight: 600;
+}
+
+table th, table td {
+  border: 1px solid var(--border-color);
+  padding: 0.5em 1em;
+}
+
+// table tr {
+//   background-color: var(--bg-color);
+// }
+
+// table tr:nth-child(2n) {
+//   background-color: var(--bg-content-color);
+// }


### PR DESCRIPTION
before:
<img width="938" alt="image" src="https://github.com/user-attachments/assets/876e0f43-9895-4f1e-9491-18f7211f676e">

after:
<img width="871" alt="image" src="https://github.com/user-attachments/assets/1c07ef18-ec97-48a1-92d3-e3b16d5cd473">

before:
<img width="844" alt="image" src="https://github.com/user-attachments/assets/e2f4913e-2148-4c6d-a618-59887d785f7b">

after:
<img width="824" alt="image" src="https://github.com/user-attachments/assets/d78f1ca1-7930-4f75-8500-0a7d849a8f09">
