### PR TITLE
feat: flow-field composition presets with refresh dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pnpm-debug.log*
 .agents/memory
 
 docs/plans
+
+.playwright-cli

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,8 +1,14 @@
-interface Window {
-  /** Umami 脚本可能被广告/隐私拦截器拦截，未加载时 window.umami 为 undefined，调用处需用可选链 */
-  umami?: {
-    track: (event: string, data?: Record<string, unknown>) => void;
-  };
-  /** 刷新流场背景效果 */
-  refreshFlowField: () => void;
+import type { HomeComposition } from '~/utils/flow-field/types';
+
+declare global {
+  interface Window {
+    /** Umami 脚本可能被广告/隐私拦截器拦截，未加载时 window.umami 为 undefined，调用处需用可选链 */
+    umami?: {
+      track: (event: string, data?: Record<string, unknown>) => void;
+    };
+    /** 刷新流场背景效果（重掷整套构图：画框 + 主视觉布局 + 颜色） */
+    refreshFlowField: () => void;
+    /** 最近一次生成的首页构图，供首页主视觉根据画框协调排版 */
+    __flowFieldComposition?: HomeComposition;
+  }
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,33 +14,43 @@ import BaseLayout from '~/layouts/base-layout.astro';
 >
   <main class="fixed w-screen h-screen flex flex-col items-center text-white p-8 z-[1]">
     <div class="w-full h-full relative">
-      <!-- 中间 -->
-      <header class="absolute z-[1] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-full flex flex-col items-center justify-center text-center">
-        <!-- 主标题 -->
-        <div class="mt-12 flex flex-col items-center justify-center text-shadow-lg">
-          <div class="text-[3.8vw] max-lg:text-3xl max-sm:text-2xl font-[500] leading-[1.4]">
-            ceynri, Frontend Developer
-          </div>
-          <div class="text-[3.8vw] max-lg:text-3xl max-sm:text-2xl font-[500] leading-[1.4]">
-            based in Guangdong, China
-          </div>
-          <div class="text-[1.5vw] max-lg:text-base w-[30vw] max-lg:w-[60vw] mt-6">
+      <!-- 中间主视觉：定位到构图指定的区域（fixed，坐标与全屏画布一致），初始 opacity-0，待构图确定后再显现，避免可见的位移跳动 -->
+      <header
+        id="hero"
+        class="fixed inset-0 z-[1] flex opacity-0 transition-opacity duration-500 ease-out items-center justify-center p-[6vw]"
+      >
+        <div
+          id="hero-block"
+          class="flex flex-col text-shadow-lg items-center text-center"
+        >
+          <!-- 主标题 -->
+          <h1 class="hero-title text-[3.8vw] max-lg:text-3xl max-sm:text-2xl font-[500] leading-[1.4] m-0">
+            <div>ceynri, Frontend Developer</div>
+            <div>based in Guangdong, China</div>
+          </h1>
+          <!-- 副标题：max-width 用 em 锚定字号，无论字号由 vw 还是断点驱动，行内字数恒定 -->
+          <div class="text-[1.5vw] max-lg:text-base max-w-[20em] max-sm:max-w-[80vw] mt-6">
             我在这里写点博客，分享我对于生活与日常的一些思考。
           </div>
-        </div>
-        <!-- 入口导航栏 -->
-        <div class="flex gap-4 mt-10">
-          {HOME_ENTRY_ITEMS.map((item) => (
-            <a
-              href={item.href}
-              class="flex items-center justify-center w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 active:opacity-50 transition-[background-color,opacity] duration-300 ease-out"
-              title={item.name}
-            >
-              <item.icon class="size-6" />
-            </a>
-          ))}
+          <!-- 入口导航栏 -->
+          <div class="flex gap-4 mt-10">
+            {HOME_ENTRY_ITEMS.map((item) => (
+              <a
+                href={item.href}
+                class="flex items-center justify-center w-12 h-12 rounded-full bg-white/10 hover:bg-white/20 active:opacity-50 transition-[background-color,opacity] duration-300 ease-out"
+                title={item.name}
+              >
+                <item.icon class="size-6" />
+              </a>
+            ))}
+          </div>
         </div>
       </header>
+
+      <!-- 禁用 JS 时强制显现主视觉（hero 初始 opacity-0 依赖 JS 淡入） -->
+      <noscript>
+        <style>#hero{opacity:1!important}</style>
+      </noscript>
 
       <!-- 左上角 -->
       <div class="absolute z-[1] top-0 left-0 flex items-start justify-start">
@@ -119,4 +129,57 @@ import BaseLayout from '~/layouts/base-layout.astro';
 
   <!-- 流场背景 -->
   <FlowFieldBackground />
+
+  <script>
+    import type { HomeComposition } from '~/utils/flow-field/types';
+
+    // 主视觉外层 / 内层的固定基础类，与模板初始类保持一致（仅保留 opacity 过渡，不含位移动画）
+    const HERO_WRAP_BASE = 'fixed z-[1] flex transition-opacity duration-500 ease-out';
+    const HERO_BLOCK_BASE = 'flex flex-col text-shadow-lg';
+
+    const wrap = () => document.getElementById('hero');
+    const block = () => document.getElementById('hero-block');
+
+    // 根据构图把主视觉定位到指定区域（瞬时生效、无位移动画），并在区域内按对齐类摆放文案，完成后淡入
+    const applyComposition = (composition: HomeComposition) => {
+      const wrapEl = wrap();
+      const blockEl = block();
+      if (!wrapEl || !blockEl) {
+        return;
+      }
+      const { left, top, width, height } = composition.heroRegion;
+      wrapEl.className = `${HERO_WRAP_BASE} ${composition.heroWrapClass}`;
+      wrapEl.style.left = `${left}px`;
+      wrapEl.style.top = `${top}px`;
+      wrapEl.style.width = `${width}px`;
+      wrapEl.style.height = `${height}px`;
+      blockEl.className = `${HERO_BLOCK_BASE} ${composition.heroBlockClass}`;
+      wrapEl.style.opacity = '1';
+    };
+
+    window.addEventListener('flowfield:composition', (event) => {
+      applyComposition((event as CustomEvent<HomeComposition>).detail);
+    });
+
+    // 刷新时随背景一起淡出，重定位在不可见状态下完成
+    window.addEventListener('flowfield:fadeout', () => {
+      const wrapEl = wrap();
+      if (wrapEl) {
+        wrapEl.style.opacity = '0';
+      }
+    });
+
+    // 兜底：若构图在监听器注册前已生成，立即应用
+    if (window.__flowFieldComposition) {
+      applyComposition(window.__flowFieldComposition);
+    }
+
+    // 安全兜底：即便背景脚本异常未派发构图，也在超时后以默认居中布局显现，避免主视觉永久隐藏
+    window.setTimeout(() => {
+      const wrapEl = wrap();
+      if (wrapEl && wrapEl.style.opacity !== '1') {
+        wrapEl.style.opacity = '1';
+      }
+    }, 1200);
+  </script>
 </BaseLayout>

--- a/src/utils/flow-field/composition.ts
+++ b/src/utils/flow-field/composition.ts
@@ -1,0 +1,181 @@
+import type { Box, CompositionPreset, Frame, SelectedComposition } from './types';
+
+/** 画框相对视口较短边的内缩边距比例（装裱 / 顶窗类使用） */
+const MARGIN_RATIO = 0.06;
+/** 上下横向画框占据视口高度的比例 */
+const BAND_RATIO = 0.5;
+/** 左右纵向画框占据视口宽度的比例 */
+const SPLIT_RATIO = 0.5;
+/** 顶部窗口画框占据视口高度的比例 */
+const TOP_WINDOW_RATIO = 0.6;
+
+/**
+ * 主视觉「安全区」内缩（px）：避让四角固定 chrome（站名 / 社交图标 / 头像 / 版权）。
+ * 这些 chrome 是绝对尺寸、与屏幕大小无关，故此处用常量而非比例——文案被约束在安全区内，
+ * 任何屏幕尺寸下都不会与四角元素冲突，无需针对具体尺寸打补丁。
+ */
+const SAFE_TOP = 64;
+const SAFE_BOTTOM = 96;
+
+/**
+ * 将数值约束到区间内
+ */
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * 画框内缩边距（px），随视口较短边缩放并做上下限约束
+ */
+function margin(vw: number, vh: number) {
+  return Math.round(clamp(Math.min(vw, vh) * MARGIN_RATIO, 24, 72));
+}
+
+/**
+ * 主视觉安全区：视口减去四角 chrome 的内缩后剩余的矩形。左右内缩随视口略微缩放，
+ * 上下为清除四角元素所需的固定像素。所有构图共用同一安全区，仅靠对齐方式决定文案落点。
+ */
+function safeRegion(vw: number, vh: number): Box {
+  const side = Math.round(clamp(vw * MARGIN_RATIO, 24, 100));
+  return { left: side, top: SAFE_TOP, width: vw - side * 2, height: vh - SAFE_TOP - SAFE_BOTTOM };
+}
+
+/**
+ * 首页构图预设列表：每个预设是一组搭配好的「背景画框 + 文案落点」。
+ *
+ * 设计模型：
+ * - 文案统一落在「安全区」内（见 safeRegion），从根本上避免与四角固定 chrome 冲突；
+ * - 背景画框（frame）是一块艺术性矩形，允许与文案重叠——重叠时靠 text-shadow 保证可读；
+ * - 每个预设仅通过 heroWrapClass 的对齐方式决定文案锚定在安全区的哪个边 / 角：
+ *   背景不覆盖该锚点时自然形成「留白分离」，屏幕过小放不下时优雅降级为「叠加」。
+ * 说明：heroWrapClass / heroBlockClass 以字面量形式列在此处供 Tailwind 静态提取。
+ */
+const PRESETS: CompositionPreset[] = [
+  // 全屏铺满 + 文案居中叠加
+  {
+    name: 'fullbleed-center',
+    supportsMobile: true,
+    frame: (vw, vh) => ({ width: vw, height: vh, left: 0, top: 0 }),
+    heroWrapClass: 'items-center justify-center',
+    heroBlockClass: 'items-center text-center',
+  },
+  // 装裱式：四周留黑边画框，文案居中叠加
+  {
+    name: 'poster-inset',
+    supportsMobile: true,
+    frame: (vw, vh) => {
+      const m = margin(vw, vh);
+      return { width: vw - m * 2, height: vh - m * 2, left: m, top: m };
+    },
+    heroWrapClass: 'items-center justify-center',
+    heroBlockClass: 'items-center text-center',
+  },
+  // 顶部窗口画框 + 文案落在窗口下方、居中
+  {
+    name: 'top-window',
+    supportsMobile: true,
+    frame: (vw, vh) => {
+      const m = margin(vw, vh);
+      return { width: vw - m * 2, height: Math.round(vh * TOP_WINDOW_RATIO) - m, left: m, top: m };
+    },
+    heroWrapClass: 'items-end justify-center pb-[2vh]',
+    heroBlockClass: 'items-center text-center',
+  },
+  // 上方横向画框 + 文案落在下方、靠左编排（左右结构）
+  // 文案被压进半屏高的横带，宽屏下主标题降一档避免过挤；lg: 限定只在宽屏生效，
+  // 保留 h1 自带的窄屏字号兜底（band-top 支持移动端，裸 vw 覆盖会让手机端标题过小）
+  {
+    name: 'band-top',
+    supportsMobile: true,
+    frame: (vw, vh) => ({ width: vw, height: Math.round(vh * BAND_RATIO), left: 0, top: 0 }),
+    heroWrapClass: 'items-end justify-start',
+    heroBlockClass: 'items-start text-left lg:[&_.hero-title]:text-[3vw]',
+  },
+  // 下方横向画框 + 文案落在上方、居中（顶部居中天然避开四角 chrome，仅宽屏以免移动端文案过高）
+  {
+    name: 'band-bottom',
+    supportsMobile: false,
+    frame: (vw, vh) => {
+      const h = Math.round(vh * BAND_RATIO);
+      return { width: vw, height: h, left: 0, top: vh - h };
+    },
+    heroWrapClass: 'items-start justify-center',
+    heroBlockClass: 'items-center text-center lg:[&_.hero-title]:text-[3vw]',
+  },
+  // 左半屏纵向画框 + 文案居右半屏（仅宽屏）
+  {
+    name: 'split-left',
+    supportsMobile: false,
+    frame: (vw, vh) => ({ width: Math.round(vw * SPLIT_RATIO), height: vh, left: 0, top: 0 }),
+    heroWrapClass: 'items-center justify-end',
+    heroBlockClass: 'items-end text-right max-w-[38vw] [&_.hero-title]:text-[2.4vw]',
+  },
+  // 右半屏纵向画框 + 文案居左半屏（仅宽屏）
+  {
+    name: 'split-right',
+    supportsMobile: false,
+    frame: (vw, vh) => {
+      const w = Math.round(vw * SPLIT_RATIO);
+      return { width: w, height: vh, left: vw - w, top: 0 };
+    },
+    heroWrapClass: 'items-center justify-start',
+    heroBlockClass: 'items-start text-left max-w-[38vw] [&_.hero-title]:text-[2.4vw]',
+  },
+];
+
+/** localStorage 键：记录上一次随机选中的构图名，供下次刷新时排除，保证连续两次效果不同 */
+const LAST_PRESET_KEY = 'flowfield:last-preset';
+
+/**
+ * 判断当前视口是否为窄屏（移动端 / 竖屏），此时排除左右分栏、下横带等宽屏专属构图
+ */
+function isNarrowScreen(vw: number, vh: number) {
+  return vw < 640 || vw < vh;
+}
+
+/**
+ * 读取 URL 中 `?layout=<预设名>` 指定的强制构图（用于预览 / 联调特定布局），无则返回 null
+ */
+function forcedPreset(): CompositionPreset | null {
+  const name = new URLSearchParams(window.location.search).get('layout');
+  return name ? (PRESETS.find((preset) => preset.name === name) ?? null) : null;
+}
+
+/**
+ * 随机生成一个首页构图
+ * @returns 选中的构图，含画框几何、主视觉区域与布局类，以及按视口重算的方法
+ */
+export function pickComposition(): SelectedComposition {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const pool = isNarrowScreen(vw, vh) ? PRESETS.filter((preset) => preset.supportsMobile) : PRESETS;
+
+  let preset: CompositionPreset;
+  const forced = forcedPreset();
+  if (forced) {
+    preset = forced;
+  } else {
+    // 随机选取：排除上一次的构图，保证连续两次刷新（含整页刷新）效果不同；
+    // 排除后候选为空时（如构图池仅剩一个）回退到完整池，避免选不出。
+    const lastName = localStorage.getItem(LAST_PRESET_KEY);
+    const candidates = pool.filter((item) => item.name !== lastName);
+    const finalPool = candidates.length > 0 ? candidates : pool;
+    preset = finalPool[Math.floor(Math.random() * finalPool.length)];
+    localStorage.setItem(LAST_PRESET_KEY, preset.name);
+  }
+
+  const recompute = (w: number, h: number): { frame: Frame; region: Box } => ({
+    frame: preset.frame(w, h),
+    region: safeRegion(w, h),
+  });
+  const { frame, region } = recompute(vw, vh);
+
+  return {
+    name: preset.name,
+    frame,
+    heroRegion: region,
+    heroWrapClass: preset.heroWrapClass,
+    heroBlockClass: preset.heroBlockClass,
+    recompute,
+  };
+}

--- a/src/utils/flow-field/sketch.ts
+++ b/src/utils/flow-field/sketch.ts
@@ -1,51 +1,95 @@
 import type P5 from 'p5';
 import { throttle } from '~/utils';
+import { pickComposition } from './composition';
 import { BG_COLOR } from './config';
 import { ParticleSystem } from './particle-system';
-import type { AppOptions } from './types';
+import type { Frame, HomeComposition, SelectedComposition } from './types';
 import { generateRandomOptions } from './utils';
 
 export function sketch(p5: P5, container: HTMLElement) {
   let particleSystem: ParticleSystem;
   let bgColor: P5.Color;
+  let canvasEl: HTMLCanvasElement;
+  let composition: SelectedComposition;
 
   // 禁用 P5 的友好错误提示以提升性能
   p5.disableFriendlyErrors = true;
 
+  // 将画框几何应用到画布元素：画布在容器内绝对定位，画框以外区域即为容器的纯黑留白
+  const applyFrame = (frame: Frame) => {
+    p5.resizeCanvas(frame.width, frame.height);
+    canvasEl.style.left = `${frame.left}px`;
+    canvasEl.style.top = `${frame.top}px`;
+  };
+
+  // 广播当前构图，供首页主视觉根据画框协调排版
+  const emitComposition = () => {
+    const detail: HomeComposition = {
+      name: composition.name,
+      heroRegion: composition.heroRegion,
+      heroWrapClass: composition.heroWrapClass,
+      heroBlockClass: composition.heroBlockClass,
+    };
+    window.__flowFieldComposition = detail;
+    window.dispatchEvent(new CustomEvent('flowfield:composition', { detail }));
+  };
+
+  // 重掷整套构图：重选画框 + 重建粒子 + 广播新布局，配合淡入淡出过渡
+  const reroll = () => {
+    composition = pickComposition();
+    applyFrame(composition.frame);
+    particleSystem = new ParticleSystem(p5, generateRandomOptions());
+    p5.background(bgColor);
+    emitComposition();
+  };
+
   p5.setup = () => {
     const canvas = p5.createCanvas(p5.windowWidth, p5.windowHeight);
-    const canvasElement = canvas.elt as HTMLElement;
+    canvasEl = canvas.elt as HTMLCanvasElement;
 
-    canvasElement.setAttribute('aria-label', '基于柏林噪声的流场背景动画');
-    canvasElement.setAttribute('role', 'img');
-
-    p5.resizeCanvas(container.clientWidth, container.clientHeight);
+    canvasEl.setAttribute('aria-label', '基于柏林噪声的流场背景动画');
+    canvasEl.setAttribute('role', 'img');
+    // 画布在容器内绝对定位，容器铺满视口且背景为纯黑
+    canvasEl.style.position = 'absolute';
+    canvasEl.style.transition = 'opacity 0.6s ease';
+    canvasEl.style.opacity = '0';
+    container.style.backgroundColor = BG_COLOR;
 
     // 禁用抗锯齿
     p5.smooth();
     // 禁用描边
     p5.noStroke();
 
-    particleSystem = new ParticleSystem(p5, generateRandomOptions());
-
     bgColor = p5.color(BG_COLOR);
-    p5.background(bgColor);
+    reroll();
+
+    // 首次绘制后淡入
+    requestAnimationFrame(() => {
+      canvasEl.style.opacity = '1';
+    });
   };
 
   p5.draw = () => {
     particleSystem.update();
   };
 
-  // 窗口尺寸变化时重置画布并重建粒子，加节流避免 resize 高频触发
+  // 窗口尺寸变化时按当前构图重算画框与主视觉区域并重建粒子，加节流避免 resize 高频触发
   p5.windowResized = throttle(() => {
-    p5.resizeCanvas(container.clientWidth, container.clientHeight);
+    const { frame, region } = composition.recompute(window.innerWidth, window.innerHeight);
+    composition = { ...composition, frame, heroRegion: region };
+    applyFrame(composition.frame);
     particleSystem.initParticles();
     p5.background(bgColor);
+    emitComposition();
   }, 200);
 
   window.refreshFlowField = () => {
-    const options: AppOptions = generateRandomOptions();
-    particleSystem = new ParticleSystem(p5, options);
-    p5.background(bgColor);
+    // 先淡出（同时通知主视觉一起淡出），在不可见状态下重掷并重定位，再淡入，避免可见的位移跳动
+    canvasEl.style.opacity = '0';
+    window.dispatchEvent(new Event('flowfield:fadeout'));
+    window.setTimeout(() => {
+      reroll();
+      canvasEl.style.opacity = '1';
+    }, 250);
   };
 }

--- a/src/utils/flow-field/types.ts
+++ b/src/utils/flow-field/types.ts
@@ -41,3 +41,74 @@ export interface AppOptionsRange {
   size: [number, number];
   noiseScale: [number, number];
 }
+
+/**
+ * 画框几何：背景动效实际渲染的矩形窗口
+ */
+export interface Frame {
+  /** 画框宽度（px） */
+  width: number;
+  /** 画框高度（px） */
+  height: number;
+  /** 相对视口左上角的水平偏移（px） */
+  left: number;
+  /** 相对视口左上角的垂直偏移（px） */
+  top: number;
+}
+
+/**
+ * 矩形区域：以视口左上角为原点的定位盒
+ */
+export interface Box {
+  /** 相对视口左上角的水平偏移（px） */
+  left: number;
+  /** 相对视口左上角的垂直偏移（px） */
+  top: number;
+  /** 宽度（px） */
+  width: number;
+  /** 高度（px） */
+  height: number;
+}
+
+/**
+ * 首页构图预设：一组搭配好的「背景画框 + 文案落点」。
+ * 文案统一落在安全区（避让四角 chrome），仅通过对齐方式决定锚定在安全区的哪个边 / 角。
+ */
+export interface CompositionPreset {
+  /** 预设名，用于调试与埋点 */
+  name: string;
+  /** 是否适用于窄屏（移动端 / 竖屏） */
+  supportsMobile: boolean;
+  /** 由视口尺寸计算背景画框几何 */
+  frame: (vw: number, vh: number) => Frame;
+  /** 主视觉外层定位类：在安全区内摆放整个文案块（决定锚定边 / 角） */
+  heroWrapClass: string;
+  /** 主视觉内层对齐类：块内标题 / 副标题 / 导航的对齐与尺寸 */
+  heroBlockClass: string;
+}
+
+/**
+ * 首页构图广播消息：背景脚本经 window 事件 / `__flowFieldComposition` 传给主视觉的排版信息，
+ * 是 SelectedComposition 中与主视觉排版相关的子集（不含画框几何与 recompute）。
+ * 作为跨脚本边界（sketch 生产 / index 消费 / window 全局声明）的唯一类型来源。
+ */
+export interface HomeComposition {
+  /** 预设名 */
+  name: string;
+  /** 当前视口下的主视觉区域 */
+  heroRegion: Box;
+  /** 主视觉外层定位类 */
+  heroWrapClass: string;
+  /** 主视觉内层对齐类 */
+  heroBlockClass: string;
+}
+
+/**
+ * 一次随机选中的首页构图：在广播消息基础上附加画框几何与按视口重算的方法
+ */
+export interface SelectedComposition extends HomeComposition {
+  /** 当前视口下的画框几何 */
+  frame: Frame;
+  /** 按新的视口尺寸重新计算画框与主视觉区域（用于窗口 resize） */
+  recompute: (vw: number, vh: number) => { frame: Frame; region: Box };
+}


### PR DESCRIPTION
## Summary

Implements a composition preset system for the homepage flow-field animation, partially addressing #23 (more interesting homepage themes).

### What's included

- **`composition.ts` (new)**: Preset pool with named compositions (`band-top` / `band-bottom` / `split-left` / `split-right` / `fullbleed-center` / `poster-inset`), responsive narrow-screen filtering, and `?layout=` forced preview for debugging.
- **Unified `HomeComposition` type**: Removes cross-file type duplication — `types.ts` is now the single source, consumed by `sketch.ts`, `index.astro`, and `env.d.ts`.
- **Refresh dedup via localStorage**: Each refresh (button click or full page reload) excludes the last-used preset, so consecutive refreshes always yield a different composition.
- **Band layout tuning**: Lower `band-top` / `band-bottom` hero title to `3vw` at `lg:` breakpoint to balance the half-height band layout (does not affect mobile).
- **Ignore `.playwright-cli`** temp artifacts.

### Verification

- `astro check`: 0 errors / 0 warnings / 0 hints
- `biome check`: clean
- Playwright manual test: 6 consecutive button refreshes + 3 full reloads all showed different adjacent presets

### Out of scope

Deploy workflow changes (`.github/workflows/deploy-tencent-cos.yml`) are handled in a separate session and intentionally excluded from this PR.

Refs #23