### PR TITLE
feat: expand umami event tracking and upgrade CDN deploy strategy

### DIFF
--- a/.github/workflows/deploy-tencent-cos.yml
+++ b/.github/workflows/deploy-tencent-cos.yml
@@ -119,12 +119,12 @@ jobs:
           echo "📊 Build output size: $(du -sh dist)"
 
       # 12. 部署到腾讯云 COS 并刷新 CDN
-      # 使用 fork tag：在官方 v1.5.2 基础上新增 cdn_purge_index_as_dir 与
+      # 使用 fork 正式版 v1.6.0：在官方 v1.5.2 基础上新增 cdn_purge_index_as_dir 与
       # cdn_purge_strategy/cdn_flush_type（目录级刷新），已向上游提交 issue/PR，
       # 待上游采纳后可切回官方 tag
       # https://github.com/sylingd/tencent-cos-and-cdn-action
       - name: Deploy to Tencent COS and refresh CDN
-        uses: ceynri/tencent-cos-and-cdn-action@v1.5.2-cdn-purge
+        uses: ceynri/tencent-cos-and-cdn-action@v1.6.0
         with:
           # 腾讯云 API 密钥 ID
           secret_id: ${{ secrets.TENCENT_SECRET_ID }}

--- a/.github/workflows/deploy-tencent-cos.yml
+++ b/.github/workflows/deploy-tencent-cos.yml
@@ -119,11 +119,12 @@ jobs:
           echo "📊 Build output size: $(du -sh dist)"
 
       # 12. 部署到腾讯云 COS 并刷新 CDN
-      # 使用 fork 分支：在官方 v1.5.2 基础上新增 cdn_purge_index_as_dir，
-      # 已向上游提交 issue/PR，待上游采纳后可切回官方 tag
+      # 使用 fork tag：在官方 v1.5.2 基础上新增 cdn_purge_index_as_dir 与
+      # cdn_purge_strategy/cdn_flush_type（目录级刷新），已向上游提交 issue/PR，
+      # 待上游采纳后可切回官方 tag
       # https://github.com/sylingd/tencent-cos-and-cdn-action
       - name: Deploy to Tencent COS and refresh CDN
-        uses: ceynri/tencent-cos-and-cdn-action@v1.5.2-purge-index-as-dir
+        uses: ceynri/tencent-cos-and-cdn-action@v1.5.2-cdn-purge
         with:
           # 腾讯云 API 密钥 ID
           secret_id: ${{ secrets.TENCENT_SECRET_ID }}
@@ -147,8 +148,10 @@ jobs:
           cdn_prefix: ${{ secrets.TENCENT_CDN_PREFIX }}
           # 等待 CDN 刷新完成再结束 step
           cdn_wait_flush: true
-          # index.html 变更时额外刷新其所在目录的 URL（如 page/ 而非 page/index.html）
-          cdn_purge_index_as_dir: true
+          # CDN 刷新策略：path=强制目录刷新（PurgePathCache），不依赖增量 diff，可根治缓存漂移
+          cdn_purge_strategy: path
+          # flush=回源比对 Last-Modify、仅变更资源重拉取，回源压力小于 delete
+          cdn_flush_type: flush
           # 项目文件本地路径
           local_path: dist
           # COS 桶上传路径

--- a/src/components/base-head.astro
+++ b/src/components/base-head.astro
@@ -140,4 +140,5 @@ const pageImage = new URL(image || '/favicon.png', Astro.site);
   defer
   src="https://stats.ceynri.cn/script.js"
   data-website-id={UMAMI_WEBSITE_ID}
+  data-performance="true"
 ></script>

--- a/src/components/theme-toggle-button.astro
+++ b/src/components/theme-toggle-button.astro
@@ -24,6 +24,8 @@ buttons.forEach((button) => {
     window.umami?.track('theme-toggle-button', {
       theme: newTheme,
     });
+    // 同步刷新会话维度，使后续行为可按切换后的配色方案分段
+    window.umami?.identify?.({ theme: newTheme });
   });
 });
 </script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,6 +5,8 @@ declare global {
     /** Umami 脚本可能被广告/隐私拦截器拦截，未加载时 window.umami 为 undefined，调用处需用可选链 */
     umami?: {
       track: (event: string, data?: Record<string, unknown>) => void;
+      /** 为当前会话附加可分段的自定义属性（如配色方案），便于按维度分析行为；老版本 tracker 可能没有，调用处用可选链 */
+      identify?: (sessionData: Record<string, unknown>) => void;
     };
     /** 刷新流场背景效果（重掷整套构图：画框 + 主视觉布局 + 颜色） */
     refreshFlowField: () => void;

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -23,12 +23,22 @@ const { title, description, image } = Astro.props;
     <slot />
 
     <script>
-      // 外链点击事件上报 umami
-      const name = 'outbound-link';
+      // 链接点击事件上报 umami：区分「外链」与「端内跳转」，事件的当前页 URL 由 umami 自动携带（即「从哪来」），事件数据只记「去哪」
+      // - outbound-link：跳出本站的外链
+      // - internal-link：站内页面跳转，用于区分某次 PV 是直接进入还是站内点击跳转而来
+      // 跳过：已显式声明 data-umami-event 的链接、非 http(s) 协议（mailto/tel/javascript 等）、纯页内锚点（同 path 仅切 hash）
       document.querySelectorAll('a').forEach((a) => {
-        if (a.host !== window.location.host && !a.getAttribute('data-umami-event')) {
-          a.setAttribute('data-umami-event', name);
+        if (a.getAttribute('data-umami-event')) return;
+        if (a.protocol !== 'http:' && a.protocol !== 'https:') return;
+
+        if (a.host !== window.location.host) {
+          a.setAttribute('data-umami-event', 'outbound-link');
           a.setAttribute('data-umami-event-url', a.href);
+        } else {
+          // 纯页内锚点（如目录跳转）不算跳转，另有专门埋点
+          if (a.pathname === window.location.pathname && a.hash) return;
+          a.setAttribute('data-umami-event', 'internal-link');
+          a.setAttribute('data-umami-event-url', a.pathname);
         }
       });
     </script>

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -23,23 +23,36 @@ const { title, description, image } = Astro.props;
     <slot />
 
     <script>
-      // 链接点击事件上报 umami：区分「外链」与「端内跳转」，事件的当前页 URL 由 umami 自动携带（即「从哪来」），事件数据只记「去哪」
+      // 链接点击事件上报 umami：区分「外链」「端内跳转」「联系方式」，事件的当前页 URL 由 umami 自动携带（即「从哪来」），事件数据只记「去哪」
       // - outbound-link：跳出本站的外链
       // - internal-link：站内页面跳转，用于区分某次 PV 是直接进入还是站内点击跳转而来
-      // 跳过：已显式声明 data-umami-event 的链接、非 http(s) 协议（mailto/tel/javascript 等）、纯页内锚点（同 path 仅切 hash）
+      // - contact-link：mailto/tel 等联系方式点击，视作一次联系转化
+      // 跳过：javascript: 等其余协议、纯页内锚点（同 path 仅切 hash，另有专门埋点）、已显式声明 data-umami-event 的链接
       document.querySelectorAll('a').forEach((a) => {
         if (a.getAttribute('data-umami-event')) return;
+
+        if (a.protocol === 'mailto:' || a.protocol === 'tel:') {
+          a.setAttribute('data-umami-event', 'contact-link');
+          a.setAttribute('data-umami-event-url', a.href);
+          return;
+        }
         if (a.protocol !== 'http:' && a.protocol !== 'https:') return;
 
         if (a.host !== window.location.host) {
           a.setAttribute('data-umami-event', 'outbound-link');
           a.setAttribute('data-umami-event-url', a.href);
         } else {
-          // 纯页内锚点（如目录跳转）不算跳转，另有专门埋点
           if (a.pathname === window.location.pathname && a.hash) return;
           a.setAttribute('data-umami-event', 'internal-link');
           a.setAttribute('data-umami-event-url', a.pathname);
         }
+      });
+
+      // 会话维度：把当前配色方案写入 umami session，便于按 light/dark 分段分析行为差异。
+      // umami 脚本 defer 加载，用 load 事件确保其已就绪；主题切换时在 theme-toggle-button 内同步刷新。
+      window.addEventListener('load', () => {
+        const theme = document.documentElement.getAttribute('data-scheme') || 'light';
+        window.umami?.identify?.({ theme });
       });
     </script>
   </body>

--- a/src/layouts/blog-post-layout.astro
+++ b/src/layouts/blog-post-layout.astro
@@ -42,4 +42,24 @@ const { headings } = await render(post);
 
   <!-- 浮动图片组件 -->
   <FloatingImages />
+
+  <script>
+    // 埋点：读到文末（视作读完）。在正文末尾插入零高哨兵，进入视口即一次性上报。
+    // 用 IntersectionObserver 而非滚动监听，开销低；且不依赖仅在宽屏接线的 TOC，全尺寸生效。
+    // 本站为 MPA（无视图过渡），随整页加载执行一次即可。
+    const article = document.querySelector('[data-toc-body]');
+    if (article) {
+      const sentinel = document.createElement('div');
+      sentinel.setAttribute('aria-hidden', 'true');
+      article.appendChild(sentinel);
+      const observer = new IntersectionObserver((entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          window.umami?.track('post-read');
+          observer.disconnect();
+          sentinel.remove();
+        }
+      });
+      observer.observe(sentinel);
+    }
+  </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary

本批改动围绕「埋点完善」与「CDN 部署策略升级」两条线：

**Umami 埋点扩展**
- 区分站内跳转（internal-link）/ 外链（outbound-link）/ 联系方式（contact-link）三类链接点击事件，事件数据记目标 URL，来源页由 umami 自动携带
- 博客正文末尾插入零高哨兵，IntersectionObserver 一次性上报 `post-read`（读到文末视作读完）
- 开启 umami 性能采集（`data-performance`）
- 通过 `umami.identify` 把当前配色方案写入会话维度，主题切换时同步刷新，便于按 light/dark 分段分析行为

**CDN 部署策略升级**
- 切换到 fork 正式版 `v1.6.0`（含 `cdn_purge_strategy` / `cdn_flush_type`）
- 采用 `path`（目录级 PurgePathCache）+ `flush`（回源比对 Last-Modify）策略，根治缓存漂移

## Test Plan

- [x] `pnpm test` — 39 tests passed
- [x] `pnpm build` — astro check + build 成功（31 pages）
- [x] `biome ci ./src ./astro.config.ts` — 无错误
- [ ] CI 四绿（astro check / biome ci / astro build / 死链检查）
- [ ] 部署后抽查 umami 后台是否收到 internal-link / contact-link / post-read / theme 会话维度