### PR TITLE
feat(blog): show estimated reading time alongside the post date

### DIFF
--- a/src/components/blog-post.astro
+++ b/src/components/blog-post.astro
@@ -4,6 +4,7 @@ import type { CollectionEntry } from 'astro:content';
 import { render } from 'astro:content';
 
 import { FormattedDate, PostTags } from '~/components';
+import { readingMinutes } from '~/utils';
 
 interface Props {
   post: CollectionEntry<'blog'>;
@@ -12,6 +13,7 @@ interface Props {
 const { post } = Astro.props as Props;
 const { title, date, cover_image, lastmod, tags, slug } = post.data;
 const { Content } = await render(post);
+const readTime = `${readingMinutes(post.body ?? '')} min read`;
 ---
 
 <main class="prose-card max-sm:rounded-none">
@@ -30,6 +32,8 @@ const { Content } = await render(post);
           <h1 class="text-3xl font-[700] text-white text-shadow-lg">{title}</h1>
           <div class="mt-3 text-white text-shadow-lg">
             <FormattedDate date={date} />
+            <span class="mx-2 opacity-60">·</span>
+            <span>{readTime}</span>
           </div>
         </div>
       </div>
@@ -37,8 +41,10 @@ const { Content } = await render(post);
     : (
       <div class="py-8 flex flex-col items-center">
         <h1 class="text-3xl font-[700]">{title}</h1>
-        <div class="mt-3">
+        <div class="mt-3 text-text-secondary">
           <FormattedDate date={date} />
+          <span class="mx-2 opacity-60">·</span>
+          <span>{readTime}</span>
         </div>
       </div>
     )}

--- a/src/components/post-card.astro
+++ b/src/components/post-card.astro
@@ -3,12 +3,14 @@ import { Picture } from 'astro:assets';
 import type { CollectionEntry } from 'astro:content';
 
 import { FormattedDate } from '~/components';
+import { readingMinutes } from '~/utils';
 
 interface Props {
   post: CollectionEntry<'blog'>;
 }
 
 const { post } = Astro.props as Props;
+const readTime = `${readingMinutes(post.body ?? '')} min read`;
 ---
 
 <div class="mb-8 rounded-2xl overflow-hidden bg-prose-bg transition-[background-color,translate] duration-300 ease-out sm:hover:-translate-y-1">
@@ -27,6 +29,8 @@ const { post } = Astro.props as Props;
       {post.data.description && <p class="mb-4 text-lg">{post.data.description}</p>}
       <p class="text-base text-text-secondary mb-0">
         <FormattedDate date={post.data.date} />
+        <span class="mx-2 opacity-60">·</span>
+        <span>{readTime}</span>
       </p>
     </div>
   </a>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './group-posts';
 export * from './limit-to-interval';
 export * from './published-post-filter';
 export * from './throttle';
+export * from './word-count';

--- a/src/utils/word-count.ts
+++ b/src/utils/word-count.ts
@@ -1,0 +1,60 @@
+/**
+ * 阅读时长估算（分钟）。
+ *
+ * 统计方式：中文字符按「字」计、英文/数字按「词」计；正文里的代码、文字都计入，
+ * 只剥掉 frontmatter（元数据）与图片语法（图片改为单独按秒计入）。
+ *
+ * 阅读速度取自阅读研究而非经验拍脑袋：
+ * - 中文默读约 260 字/分钟（C-READ、Brussee 等汉语阅读研究，多个研究落在 255–273 字/分）
+ * - 英文默读约 238 词/分钟（Brysbaert 2019 元分析，190 项研究，非小说类）
+ * 另加少量起步冗余，模拟读者进入阅读状态前的慢热，也避免短文被算成瞬间读完。
+ */
+
+// 中文默读速度（字/分钟）
+const CJK_CHARS_PER_MIN = 260;
+// 英文默读速度（词/分钟）
+const LATIN_WORDS_PER_MIN = 238;
+// 每张图片的停留时长（秒）：多数人扫图不停留，取略作停留与一扫而过之间的折中
+const SECONDS_PER_IMAGE = 5;
+// 起步冗余（秒）：进入阅读状态前的慢热时间
+const WARMUP_SECONDS = 30;
+
+/**
+ * 估算阅读时长（分钟，四舍五入，至少 1 分钟）。
+ * @param markdown 文章正文 Markdown 原文
+ */
+export function readingMinutes(markdown: string): number {
+  // 只去 frontmatter（元数据，非正文）。
+  // post.body 已不含 frontmatter；正文里可能含 `---` 水平线。
+  // 故仅当首行是完整定界线、且次行形似 YAML 键值时才按 frontmatter 剥离，
+  // 避免把「以水平线开头的正文」误吞。
+  const hasFrontmatter = /^---[ \t]*\r?\n[\w-]+\s*:/.test(markdown);
+  const body = hasFrontmatter ? markdown.replace(/^---[\s\S]*?^---[ \t]*\r?\n/m, '') : markdown;
+
+  // 图片：单独按秒计，语法本身不算字。覆盖 Markdown 与 HTML 两种写法
+  const imageCount = (body.match(/!\[[^\]]*\]\([^)]*\)/g) || []).length + (body.match(/<img\b/gi) || []).length;
+
+  // 剥掉「非内容」的语法符号，但保留文字与代码内容本身：
+  const text = body
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // 图片整体去掉（含 URL）
+    .replace(/<img\b[^>]*>/gi, '') // HTML img 标签
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // 链接保留文字、去 URL
+    .replace(/```[^\n]*\n?/g, '') // 代码块围栏（保留块内代码）
+    // 仅剥离合法 HTML 标签，避免误删正文里的比较符（a < b > c）或 <词语> 这类强调
+    .replace(/<\/?[a-zA-Z][a-zA-Z0-9-]*(\s[^>]*)?\/?>/g, '');
+
+  // 中文字符按字计（含日文假名，避免日文词汇完全漏算）
+  const cjkRe = /[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff\u3040-\u30ff]/g;
+  const cjkCount = (text.match(cjkRe) || []).length;
+  // 剔除中文与全角标点后，英文/数字按词计
+  const nonCJK = text.replace(cjkRe, ' ').replace(/[\u3000-\u303f\uff00-\uffef]/g, ' ');
+  const wordCount = (nonCJK.match(/[a-zA-Z0-9]+/g) || []).length;
+
+  const totalSeconds =
+    (cjkCount / CJK_CHARS_PER_MIN) * 60 +
+    (wordCount / LATIN_WORDS_PER_MIN) * 60 +
+    imageCount * SECONDS_PER_IMAGE +
+    WARMUP_SECONDS;
+
+  return Math.max(1, Math.round(totalSeconds / 60));
+}


### PR DESCRIPTION
在文章详情页头部和博客列表卡片上，于日期同行显示「N min read」阅读时长预估，风格与英文日期一致。

## 算法
阅读速度取自阅读研究，非拍脑袋：
- 中文默读 **~260 字/分**（C-READ、Brussee 等汉语阅读研究，多项落在 255–273 字/分）
- 英文默读 **~238 词/分**（Brysbaert 2019 元分析，190 项研究，非小说类）
- 图片 **每张 5 秒**
- 起步冗余 **+30 秒**（模拟进入阅读状态的慢热，也避免短文被算成瞬间读完）
- 正文代码、文字全部计入；四舍五入、至少 1 分钟

## 实现要点
- 工具函数 `src/utils/word-count.ts`（`readingMinutes`）
- 详情页 `blog-post.astro`（封面/无封面两种头部）+ 列表页 `post-card.astro`，均放在日期同行、以 `·` 分隔
- 只去 frontmatter 与图片语法；frontmatter 仅当文件以 `---` 定界且次行为 YAML 键时才剥离，避免误吞正文里的 `---` 水平线；HTML 标签剥离收紧为合法标签名，避免误删 `a < b > c` / `<词语>`；日文假名计入 CJK

## 验证
经 @oracle review + 全库 29 篇真实语料抽样，构建产物抽查：稻草人 13min、AI Coding 46min、露营 13min、HK 一日游 18min。

Closes #92