### PR TITLE
feat(blog): make post headings anchorable

### DIFF
--- a/src/layouts/blog-post-layout.astro
+++ b/src/layouts/blog-post-layout.astro
@@ -100,13 +100,11 @@ const { headings } = await render(post);
       position: relative;
       cursor: pointer;
     }
-    /* 缩小 hover 触发区域到文字本身：标题默认 display:block 占满整行，
-       改为 inline-block 后只包裹文字宽度；同时把 prose 排版给的 padding-top
-       转成 margin-top（padding 也算 hover 区，margin 不算），垂直间距保持不变。 */
+    /* 缩小 hover 触发区域：标题默认 display:block 占满整行，改为 inline-block
+       后只包裹文字宽度。保留 prose 的 padding-top 不动，以免影响锚定时
+       距视口顶端的间距。 */
     .typography .anchorable-heading {
       display: inline-block;
-      padding-top: 0;
-      margin-top: calc(1.75rem + 1rem);
     }
     .anchorable-heading::before {
       content: '#';

--- a/src/layouts/blog-post-layout.astro
+++ b/src/layouts/blog-post-layout.astro
@@ -91,9 +91,11 @@ const { headings } = await render(post);
     });
   </script>
 
-  <style>
+  <style is:global>
     /* 可锚定标题：低存在感提示，hover 时在标题前露出 `#`，明示可点击复制链接。
-       颜色用语义次要色，明暗主题自适应，不硬编码。 */
+       颜色用语义次要色，明暗主题自适应，不硬编码。
+       注意必须 is:global：.anchorable-heading 由下方脚本动态 classList.add，
+       元素上没有 Astro 的 scoped data 属性，带作用域的选择器匹配不到。 */
     .anchorable-heading {
       position: relative;
       cursor: pointer;

--- a/src/layouts/blog-post-layout.astro
+++ b/src/layouts/blog-post-layout.astro
@@ -100,6 +100,14 @@ const { headings } = await render(post);
       position: relative;
       cursor: pointer;
     }
+    /* 缩小 hover 触发区域到文字本身：标题默认 display:block 占满整行，
+       改为 inline-block 后只包裹文字宽度；同时把 prose 排版给的 padding-top
+       转成 margin-top（padding 也算 hover 区，margin 不算），垂直间距保持不变。 */
+    .typography .anchorable-heading {
+      display: inline-block;
+      padding-top: 0;
+      margin-top: calc(1.75rem + 1rem);
+    }
     .anchorable-heading::before {
       content: '#';
       position: absolute;

--- a/src/layouts/blog-post-layout.astro
+++ b/src/layouts/blog-post-layout.astro
@@ -75,5 +75,46 @@ const { headings } = await render(post);
       tocHoverTracked = true;
       window.umami?.track('toc-rail-hover');
     });
+
+    // 标题锚点：点击正文 h 标题 → 滚动锚定 + 更新 URL hash，便于复制可锚定的链接。
+    // 用 replaceState 而非 pushState：锚点是「同一页内的状态标注」，不应在浏览器历史里堆一条记录，
+    // 否则用户点几个标题后要按多次返回键才离开本文。
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    document.querySelectorAll<HTMLElement>('[data-toc-body] h1[id], [data-toc-body] h2[id], [data-toc-body] h3[id]').forEach((heading) => {
+      heading.classList.add('anchorable-heading');
+      heading.addEventListener('click', () => {
+        const id = heading.id;
+        if (!id) return;
+        heading.scrollIntoView({ behavior: reduceMotion.matches ? 'auto' : 'smooth', block: 'start' });
+        history.replaceState(null, '', `#${encodeURIComponent(id)}`);
+      });
+    });
   </script>
+
+  <style>
+    /* 可锚定标题：低存在感提示，hover 时在标题前露出 `#`，明示可点击复制链接。
+       颜色用语义次要色，明暗主题自适应，不硬编码。 */
+    .anchorable-heading {
+      position: relative;
+      cursor: pointer;
+    }
+    .anchorable-heading::before {
+      content: '#';
+      position: absolute;
+      left: -1.1em;
+      color: var(--text-secondary-color);
+      opacity: 0;
+      transition: opacity 0.2s ease-out;
+      font-weight: 400;
+    }
+    .anchorable-heading:hover::before {
+      opacity: 0.8;
+    }
+    /* 窄屏正文紧贴边缘，左侧没有空间放 `#`，避免裁切 */
+    @media screen and (max-width: 767px) {
+      .anchorable-heading::before {
+        content: none;
+      }
+    }
+  </style>
 </BaseLayout>


### PR DESCRIPTION
让正文 h1/h2/h3 标题可点击锚定：点击平滑滚动到标题并把 id 写入 URL hash（可复制的锚点链接），hover 时标题前露出 `#` 提示，鼠标呈 pointer。窄屏（<768px）自动隐藏 `#`。

## 实现
- `blog-post-layout.astro` 内联脚本：给 `[data-toc-body]` 内的 h1/h2/h3 加 `anchorable-heading` class + 点击监听，`scrollIntoView` + `history.replaceState` 写 hash（不污染浏览器历史）
- 样式：hover 露 `#`（左侧 -1.1em，次要色，明暗自适应）

## 修复的两个问题（含 commit）
1. **样式不生效**：Astro 给 `<style>` 加了 scoped data 属性，但 `anchorable-heading` 是运行时 `classList.add` 加的，元素上无该属性 → 改用 `<style is:global>`
2. **hover 区过大**：标题默认 block 占满整行 → 改 `inline-block` 缩到文字宽，保留 `padding-top` 不影响锚定间距

已用 ego-browser 在 dev + build 实测：hover 露 `#`、cursor pointer、点击滚动 + hash 更新均正常。

Closes #90