### PR TITLE
feat(blog): previous and next post navigation at the end of a post

### DIFF
--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -2,6 +2,8 @@
 export type { AstroComponent as LucideComponent } from '@lucide/astro';
 export {
   Archive,
+  ArrowLeft,
+  ArrowRight,
   Feather,
   House,
   Info,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ export { default as FormattedDate } from './formatted-date.astro';
 export { default as MenuButton } from './menu-button.astro';
 export { default as Pagination } from './pagination.astro';
 export { default as PostCard } from './post-card.astro';
+export { default as PostPrevNext } from './post-prev-next.astro';
 export { default as PostTags } from './post-tags.astro';
 export { default as ThemeToggleButton } from './theme-toggle-button.astro';
 export { default as TopNavbar } from './top-navbar.astro';

--- a/src/components/post-prev-next.astro
+++ b/src/components/post-prev-next.astro
@@ -1,0 +1,50 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+import { ArrowLeft, ArrowRight } from '~/components/icons';
+import { cn } from '~/utils';
+
+interface Props {
+  prev?: CollectionEntry<'blog'>;
+  next?: CollectionEntry<'blog'>;
+  class?: string;
+}
+
+const { prev, next, class: className } = Astro.props as Props;
+---
+
+{(prev || next) && (
+  <nav
+    aria-label="上一篇 / 下一篇"
+    class={cn('flex gap-4', className)}
+  >
+    {prev ? (
+      <a
+        href={`/blog/${prev.id}/`}
+        class="group flex min-w-0 flex-1 flex-col gap-1 rounded-2xl bg-tag-bg px-5 py-4 transition-[background-color] duration-300 hover:bg-pagination-active-bg"
+      >
+        <span class="flex items-center gap-1.5 text-sm text-text-secondary">
+          <ArrowLeft class="size-4 transition-transform duration-300 group-hover:-translate-x-1" />
+          上一篇
+        </span>
+        <span class="truncate font-[500] text-title">{prev.data.title}</span>
+      </a>
+    ) : (
+      <span class="flex-1" />
+    )}
+    {next ? (
+      <a
+        href={`/blog/${next.id}/`}
+        class="group flex min-w-0 flex-1 flex-col items-end gap-1 rounded-2xl bg-tag-bg px-5 py-4 text-right transition-[background-color] duration-300 hover:bg-pagination-active-bg"
+      >
+        <span class="flex items-center gap-1.5 text-sm text-text-secondary">
+          下一篇
+          <ArrowRight class="size-4 transition-transform duration-300 group-hover:translate-x-1" />
+        </span>
+        <span class="truncate font-[500] text-title">{next.data.title}</span>
+      </a>
+    ) : (
+      <span class="flex-1" />
+    )}
+  </nav>
+)}

--- a/src/components/post-prev-next.astro
+++ b/src/components/post-prev-next.astro
@@ -15,7 +15,7 @@ const { prev, next, class: className } = Astro.props as Props;
 
 {(prev || next) && (
   <nav
-    aria-label="上一篇 / 下一篇"
+    aria-label="Previous / Next post"
     class={cn('flex gap-4', className)}
   >
     {prev ? (
@@ -25,7 +25,7 @@ const { prev, next, class: className } = Astro.props as Props;
       >
         <span class="flex items-center gap-1.5 text-sm text-text-secondary">
           <ArrowLeft class="size-4 transition-transform duration-300 group-hover:-translate-x-1" />
-          上一篇
+          Prev
         </span>
         <span class="truncate font-[500] text-title">{prev.data.title}</span>
       </a>
@@ -38,7 +38,7 @@ const { prev, next, class: className } = Astro.props as Props;
         class="group flex min-w-0 flex-1 flex-col items-end gap-1 rounded-2xl bg-tag-bg px-5 py-4 text-right transition-[background-color] duration-300 hover:bg-pagination-active-bg"
       >
         <span class="flex items-center gap-1.5 text-sm text-text-secondary">
-          下一篇
+          Next
           <ArrowRight class="size-4 transition-transform duration-300 group-hover:translate-x-1" />
         </span>
         <span class="truncate font-[500] text-title">{next.data.title}</span>

--- a/src/layouts/blog-post-layout.astro
+++ b/src/layouts/blog-post-layout.astro
@@ -2,15 +2,17 @@
 import type { CollectionEntry } from 'astro:content';
 import { render } from 'astro:content';
 
-import { BlogPost, Comments, FloatingImages, Footer, TocRail, TopNavbar } from '~/components';
+import { BlogPost, Comments, FloatingImages, Footer, PostPrevNext, TocRail, TopNavbar } from '~/components';
 
 import BaseLayout from './base-layout.astro';
 
 interface Props {
   post: CollectionEntry<'blog'>;
+  prev?: CollectionEntry<'blog'>;
+  next?: CollectionEntry<'blog'>;
 }
 
-const { post } = Astro.props as Props;
+const { post, prev, next } = Astro.props as Props;
 const { title, description, cover_image, layout, tocDepth, toc } = post.data;
 
 const widthClass = layout === 'narrow' ? 'max-w-[30rem]' : 'max-w-[50rem]';
@@ -28,6 +30,11 @@ const { headings } = await render(post);
   <div class="mt-8 max-sm:mt-0 px-8 max-sm:px-0">
     <div class={`mx-auto ${widthClass} max-sm:max-w-full`}>
       <BlogPost post={post} />
+      <PostPrevNext
+        prev={prev}
+        next={next}
+        class="mt-8"
+      />
       <Comments class="mt-12" />
       <Footer class="text-center" />
     </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -12,10 +12,10 @@ export async function getStaticPaths() {
     params: { slug: post.id },
     props: {
       post,
-      // 排序为「新→旧」。对齐英文惯例：prev=较旧一篇（previous post）、
-      // next=较新一篇（next post），故在「新→旧」序列里 prev 取后一个、next 取前一个。
-      prev: posts[index + 1],
-      next: posts[index - 1],
+      // 排序为「新→旧」。本站把「新→旧」视为阅读前进方向：
+      // Prev（左）= 时间上更晚/更新的一篇，Next（右）= 时间上更早/较旧的一篇。
+      prev: posts[index - 1],
+      next: posts[index + 1],
     },
   }));
 }

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -12,9 +12,10 @@ export async function getStaticPaths() {
     params: { slug: post.id },
     props: {
       post,
-      // 排序为「新→旧」，prev=较新一篇（列表里的上一篇）、next=较旧一篇
-      prev: posts[index - 1],
-      next: posts[index + 1],
+      // 排序为「新→旧」。对齐英文惯例：prev=较旧一篇（previous post）、
+      // next=较新一篇（next post），故在「新→旧」序列里 prev 取后一个、next 取前一个。
+      prev: posts[index + 1],
+      next: posts[index - 1],
     },
   }));
 }

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -4,18 +4,31 @@ import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
 
 import { BlogPostLayout } from '~/layouts';
-import { publishedPostFilter } from '~/utils';
+import { getSortedPosts, publishedPostFilter } from '~/utils';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog', publishedPostFilter);
-  return posts.map((post) => ({
+  const posts = getSortedPosts(await getCollection('blog', publishedPostFilter));
+  return posts.map((post, index) => ({
     params: { slug: post.id },
-    props: post,
+    props: {
+      post,
+      // 排序为「新→旧」，prev=较新一篇（列表里的上一篇）、next=较旧一篇
+      prev: posts[index - 1],
+      next: posts[index + 1],
+    },
   }));
 }
-type Props = CollectionEntry<'blog'>;
+interface Props {
+  post: CollectionEntry<'blog'>;
+  prev?: CollectionEntry<'blog'>;
+  next?: CollectionEntry<'blog'>;
+}
 
-const post = Astro.props;
+const { post, prev, next } = Astro.props;
 ---
 
-<BlogPostLayout post={post} />
+<BlogPostLayout
+  post={post}
+  prev={prev}
+  next={next}
+/>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -31,6 +31,7 @@
   --color-navbar-text: var(--navbar-text-color);
   --color-tag-bg: var(--tag-bg-color);
   --color-pagination-text: var(--pagination-text-color);
+  --color-pagination-active-bg: var(--pagination-active-bg-color);
   --color-title: var(--title-color);
   --color-text: var(--text-color);
   --color-text-secondary: var(--text-secondary-color);


### PR DESCRIPTION
在文章正文末尾加 Prev / Next 导航卡片，按「新→旧」时间线串联文章。

## 行为
- 排序按 `date` 新→旧；**Prev（左）= 更新的一篇，Next（右）= 较旧的一篇**（把新→旧视作阅读前进方向）
- 最新文只有 Next，最旧文只有 Prev（另一侧占位保持布局平衡）
- 两张卡片左右排列，Prev 左对齐 + ← 箭头，Next 右对齐 + → 箭头；hover 箭头位移、背景用主题自适应色（tag-bg → pagination-active-bg）；标题 `truncate` 防溢出
- 标签用英文 Prev / Next，与英文日期、`min read` 风格统一

## 实现
- `[...slug].astro` 在 `getStaticPaths` 里排序后传 `prev`/`next`
- 新组件 `post-prev-next.astro`；`blog-post-layout.astro` 在正文后、评论区前渲染
- `icons/index.ts` 加 `ArrowLeft`/`ArrowRight`；`main.css` 注册 `pagination-active-bg` 语义色

经 build 产物 + ego-browser 实测：中间文 Prev/Next 双全、最新文仅 Next、最旧文仅 Prev，链接与排序方向均正确。

Closes #73